### PR TITLE
Fix error when volume name contain a space

### DIFF
--- a/Utilities/root/usr/local/bin/espmount.bash
+++ b/Utilities/root/usr/local/bin/espmount.bash
@@ -36,7 +36,7 @@ fi
 # find esp of boot volume
 bvs=$( system_profiler SPSoftwareDataType | grep Volume )
 bv=${bvs#*: }
-lds=$( diskutil info $bv  |  grep "Part of"          | sed -e's/^.* disk/disk/' )
+lds=$( diskutil info "$bv"  |  grep "Part of"          | sed -e's/^.* disk/disk/' )
 pds1=$( diskutil list $lds | egrep " Volume on| Store " | sed -e's/^.* disk/disk/' )
 #pds2=$( diskutil list      | egrep " Container $lds" | sed -e's/^.* disk/disk/' )
 pds=${pds1}${pds2}


### PR DESCRIPTION
When the volume name contain a space, espmount displays an error

Enter the disk number or the volume name
0
Usage:  diskutil info[rmation] [-plist]
        MountPoint|DiskIdentifier|DeviceNode|UUID | -all
Display detailed information about a disk or partition.
Root or administrator access is not required.
/Volumes/ESP